### PR TITLE
Adjust dataset loading to use downloaded .pt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a small collection of scripts for experimenting with va
    ```
    PyTorch and PyTorch Geometric must be installed with versions that match your system and CUDA setup.
 2. Download the datasets from the provided Google Drive folder by following [DOWNLOAD_INSTRUCTIONS.md](DOWNLOAD_INSTRUCTIONS.md).
+   The archives will create a `simple_data/` directory containing `.pt` files.
 3. Run an experiment:
    ```bash
    python main.py --model BaselineGCN --dataset OGB-Arxiv --epochs 20
@@ -40,6 +41,8 @@ Default hyperparameters:
 
 ## Notes
 - The datasets are large and therefore not stored in this repository.
+- After downloading they reside in `simple_data/` and are loaded directly
+  from those `.pt` files.
 - Use the command line flags in `main.py` to adjust hyperparameters or integrate new models.
 
 ## Web Interface

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def run_experiment(cfg: ExperimentConfig):
 
     sys.stdout = Stream()
     try:
-        data, feat_dim, num_classes = data_loader.load_dataset(cfg.dataset, root='data')
+        data, feat_dim, num_classes = data_loader.load_dataset(cfg.dataset, root='simple_data')
         data = data.to(device)
         name = cfg.model.lower()
         if name == 'baselinegcn':

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,203 +1,67 @@
 import os
-import zipfile
-import requests
-import pandas as pd
-import numpy as np
 import torch
-
-from torch_geometric.datasets import Reddit, WikiCS
-from torch_geometric.utils import to_undirected
-from ogb.nodeproppred import PygNodePropPredDataset
-
 from torch_geometric.data import Data, Batch
 from torch_geometric.data.data import DataEdgeAttr, DataTensorAttr
 from torch_geometric.data.storage import GlobalStorage
 import torch.serialization
 
-
-def _download_file(url, path):
-    """Helper function to download a file with progress."""
-    if not os.path.exists(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-    print(f"⬇️ Downloading {os.path.basename(path)}...")
-    try:
-        with requests.get(url, stream=True) as r:
-            r.raise_for_status()
-            with open(path, 'wb') as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    f.write(chunk)
-        print("✅ Download complete.")
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Failed to download {url}. Error: {e}")
-        raise
+# Mapping from dataset name to filename within the downloaded folder
+_DATASET_FILES = {
+    'OGB-Arxiv': 'OGB_data.pt',
+    'Reddit': 'Reddit_data.pt',
+    'TGB-Wiki': 'TGB_wiki_data.pt',
+    'MOOC': 'MOOC_data.pt',
+}
 
 
-def _load_ogb_arxiv(root):
-    from ogb.nodeproppred import PygNodePropPredDataset
-    from torch_geometric.utils import to_undirected
+_DEF_ROOT = 'simple_data'
 
-    # ✅ Allowlist necessary PyG globals for torch.load
+
+def _load_pt_dataset(pt_path):
+    """Load a PyG Data object from a .pt file."""
+    if not os.path.exists(pt_path):
+        raise FileNotFoundError(
+            f"{pt_path} not found. Download datasets using DOWNLOAD_INSTRUCTIONS.md"
+        )
+
+    # Allowlist PyG classes for torch.load
     torch.serialization.add_safe_globals([
         Data, Batch, DataEdgeAttr, DataTensorAttr, GlobalStorage
     ])
 
-    dataset = PygNodePropPredDataset(name='ogbn-arxiv', root=root)
-    data = dataset[0]
-    data.edge_index = to_undirected(data.edge_index)
+    obj = torch.load(pt_path, weights_only=False)
+    data = obj[0] if isinstance(obj, (list, tuple)) else obj
 
-    split_idx = dataset.get_idx_split()
-    data.train_mask = torch.zeros(data.num_nodes, dtype=torch.bool)
-    data.train_mask[split_idx["train"]] = True
-    data.val_mask = torch.zeros(data.num_nodes, dtype=torch.bool)
-    data.val_mask[split_idx["valid"]] = True
-    data.test_mask = torch.zeros(data.num_nodes, dtype=torch.bool)
-    data.test_mask[split_idx["test"]] = True
-
-    return data, dataset.num_node_features, dataset.num_classes
-
-
-def _load_reddit(root):
-    """Loads the Reddit dataset."""
-    dataset = Reddit(root=os.path.join(root, 'Reddit'))
-    return dataset[0], dataset.num_features, dataset.num_classes
-
-
-def _load_tgb_wiki(root):
-    """Loads the TGB-Wiki dataset, using PyG's WikiCS as a proxy."""
-    dataset = WikiCS(root=os.path.join(root, 'WikiCS'))
-    data = dataset[0]
-    # Use the first set of masks as the primary split
-    data.train_mask = data.train_mask[:, 0]
-    data.val_mask = data.val_mask[:, 0]
-    # Define test mask as nodes not in train or val
-    data.test_mask = ~(data.train_mask | data.val_mask)
-    return data, data.num_node_features, dataset.num_classes
-
-
-def _load_mooc(root):
-    """Loads and processes the MOOC dataset from raw TSV files."""
-    data_dir = os.path.join(root, "MOOC", "raw")
-    files = {
-        "features": "mooc_action_features.tsv",
-        "labels": "mooc_action_labels.tsv",
-        "actions": "mooc_actions.tsv"
-    }
-
-    # Simple check if data exists, assumes if one file is there, all are
-    if not os.path.exists(os.path.join(data_dir, files['features'])):
-        print("MOOC data not found. Generating a small synthetic version for testing purposes.")
-        num_nodes = 100
-        edge_index = torch.randint(0, num_nodes, (2, num_nodes * 2))
-        x = torch.randn(num_nodes, 4)
-        y = torch.randint(0, 2, (num_nodes,))
+    if not hasattr(data, 'train_mask'):
+        num_nodes = data.num_nodes
         idx = torch.randperm(num_nodes)
-        train_mask = torch.zeros(num_nodes, dtype=torch.bool)
-        val_mask = torch.zeros(num_nodes, dtype=torch.bool)
-        test_mask = torch.zeros(num_nodes, dtype=torch.bool)
-        train_mask[idx[:60]] = True
-        val_mask[idx[60:80]] = True
-        test_mask[idx[80:]] = True
+        train_end = int(0.6 * num_nodes)
+        val_end = int(0.8 * num_nodes)
+        data.train_mask = torch.zeros(num_nodes, dtype=torch.bool)
+        data.val_mask = torch.zeros(num_nodes, dtype=torch.bool)
+        data.test_mask = torch.zeros(num_nodes, dtype=torch.bool)
+        data.train_mask[idx[:train_end]] = True
+        data.val_mask[idx[train_end:val_end]] = True
+        data.test_mask[idx[val_end:]] = True
 
-        data = Data(x=x, edge_index=edge_index, y=y)
-        data.train_mask = train_mask
-        data.val_mask = val_mask
-        data.test_mask = test_mask
-
-        return data, x.size(1), int(y.max().item()) + 1
-
-    features_path = os.path.join(data_dir, files["features"])
-    labels_path = os.path.join(data_dir, files["labels"])
-    actions_path = os.path.join(data_dir, files["actions"])
-
-    try:
-        features_df = pd.read_csv(features_path, sep="\t")
-        labels_df = pd.read_csv(labels_path, sep="\t")
-        actions_df = pd.read_csv(actions_path, sep="\t")
-    except Exception as e:
-        print(f"Error reading MOOC TSV files: {e}")
-        raise
-
-    # Align nodes and create a contiguous mapping
-    all_ids = pd.concat([
-        features_df["ACTIONID"],
-        labels_df["ACTIONID"],
-        actions_df["USERID"],
-        actions_df["TARGETID"]
-    ]).unique()
-    all_ids.sort()
-
-    id_to_idx = {action_id: i for i, action_id in enumerate(all_ids)}
-    num_nodes = len(all_ids)
-
-    # Process features
-    x = torch.zeros((num_nodes, 4), dtype=torch.float)  # MOOC has 4 features
-    feat_mapped_ids = features_df["ACTIONID"].map(id_to_idx).to_numpy()
-    feat_values = torch.tensor(features_df.drop("ACTIONID", axis=1).values, dtype=torch.float)
-    x[feat_mapped_ids] = feat_values
-
-    # Process labels
-    y = torch.full((num_nodes,), -1, dtype=torch.long)  # Use -1 for unlabeled nodes
-    label_mapped_ids = labels_df["ACTIONID"].map(id_to_idx).to_numpy()
-    label_values = torch.tensor(labels_df["LABEL"].values, dtype=torch.long)
-    y[label_mapped_ids] = label_values
-
-    # Process edges
-    src = actions_df["USERID"].map(id_to_idx).to_numpy()
-    dst = actions_df["TARGETID"].map(id_to_idx).to_numpy()
-    edge_index = torch.tensor([src, dst], dtype=torch.long)
-
-    # Create masks for labeled nodes
-    labeled_nodes_idx = (y != -1).nonzero(as_tuple=False).view(-1)
-    np.random.shuffle(labeled_nodes_idx.numpy())  # Shuffle for random split
-
-    train_end = int(0.6 * len(labeled_nodes_idx))
-    val_end = int(0.8 * len(labeled_nodes_idx))
-
-    train_mask = torch.zeros(num_nodes, dtype=torch.bool)
-    val_mask = torch.zeros(num_nodes, dtype=torch.bool)
-    test_mask = torch.zeros(num_nodes, dtype=torch.bool)
-
-    train_mask[labeled_nodes_idx[:train_end]] = True
-    val_mask[labeled_nodes_idx[train_end:val_end]] = True
-    test_mask[labeled_nodes_idx[val_end:]] = True
-
-    data = Data(x=x, edge_index=edge_index, y=y)
-    data.train_mask = train_mask
-    data.val_mask = val_mask
-    data.test_mask = test_mask
-
-    num_classes = len(y[y != -1].unique())
-
-    return data, x.size(1), num_classes
+    feat_dim = data.x.size(1)
+    num_classes = int(data.y.max().item()) + 1
+    return data, feat_dim, num_classes
 
 
-def load_dataset(name: str, root: str = 'data'):
-    """
-    Main function to load a specified dataset.
-
-    Args:
-        name (str): The name of the dataset. One of ['OGB-Arxiv', 'Reddit', 'TGB-Wiki', 'MOOC'].
-        root (str, optional): The root directory to store the data. Defaults to 'data'.
-
-    Returns:
-        Tuple[Data, int, int]: A tuple containing the PyG Data object, number of node features, and number of classes.
-    """
-    if name not in ['OGB-Arxiv', 'Reddit', 'TGB-Wiki', 'MOOC']:
+def load_dataset(name: str, root: str = _DEF_ROOT):
+    """Load one of the preprocessed datasets from disk."""
+    if name not in _DATASET_FILES:
         raise ValueError(f"Unknown dataset: {name}")
 
     if not os.path.exists(root):
-        os.makedirs(root, exist_ok=True)
+        raise FileNotFoundError(
+            f"Dataset folder '{root}' does not exist. Follow DOWNLOAD_INSTRUCTIONS.md"
+        )
 
     print(f"\n--- Loading {name} ---")
-
-    if name == 'OGB-Arxiv':
-        data, feat_dim, num_classes = _load_ogb_arxiv(root)
-    elif name == 'Reddit':
-        data, feat_dim, num_classes = _load_reddit(root)
-    elif name == 'TGB-Wiki':
-        data, feat_dim, num_classes = _load_tgb_wiki(root)
-    elif name == 'MOOC':
-        data, feat_dim, num_classes = _load_mooc(root)
+    pt_path = os.path.join(root, _DATASET_FILES[name])
+    data, feat_dim, num_classes = _load_pt_dataset(pt_path)
 
     print(f"✅ Dataset '{name}' loaded successfully.")
     print(f"   Nodes: {data.num_nodes}, Edges: {data.num_edges}")

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def main():
     print(f"Configuration: {args}")
 
     # --- Data Loading ---
-    data, feat_dim, num_classes = data_loader.load_dataset(name=args.dataset, root="data")
+    data, feat_dim, num_classes = data_loader.load_dataset(name=args.dataset, root="simple_data")
     data = data.to(device)
 
     # --- Model Initialization ---

--- a/verify_mooc_models.py
+++ b/verify_mooc_models.py
@@ -13,7 +13,7 @@ def run_one_epoch(model, data):
 
 def main():
     device = torch.device('cpu')
-    data, feat_dim, num_classes = data_loader.load_dataset('MOOC', root='data')
+    data, feat_dim, num_classes = data_loader.load_dataset('MOOC', root='simple_data')
     data = data.to(device)
 
     models_to_test = {


### PR DESCRIPTION
## Summary
- replace dataset loader with logic to load local `.pt` archives
- point scripts to `simple_data/` folder
- note the new location of datasets in README

## Testing
- `python main.py --model BaselineGCN --dataset OGB-Arxiv --epochs 1 | head`
- `python verify_mooc_models.py | head`


------
https://chatgpt.com/codex/tasks/task_e_687c7eb1f2fc8323b0c4453960eb6c2e