### PR TITLE
Add SMOTE oversampling to datasets

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ def main():
 
     # --- Data Loading ---
     data, feat_dim, num_classes = data_loader.load_dataset(name=args.dataset, root="simple_data")
+    data = data_loader.apply_smote(data)
     data = data.to(device)
 
     # --- Model Initialization ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyg_lib
 
 gdown
 PyQt5
+imbalanced-learn


### PR DESCRIPTION
## Summary
- oversample training nodes using SMOTE when loading datasets
- add dependency on imbalanced-learn
- call SMOTE procedure in `main.py` before training

## Testing
- `python -m py_compile data_loader.py main.py train.py models.py simple_sampler.py pyqt_ui.py verify_mooc_models.py`
- `bash run_all_experiments.sh` *(fails: Dataset folder `simple_data` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688cbedfe2948323841c71d5c0b274eb