### PR TITLE
Capture logs when running all experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ This repository contains a small collection of scripts for experimenting with va
    be supplied via command line flags (see `python main.py --help`). Defaults
    for these optional values are printed as part of the configuration output.
 
+4. Run all predefined experiments and capture logs:
+   ```bash
+   bash run_all_experiments.sh
+   ```
+   Output is streamed to the console and a timestamped log is written to the
+   `logs/` directory.
+
 ### Valid command line values
 Models:
 `BaselineGCN`, `GraphSAGE`, `TGAT`, `TGN`, `AGNNet`

--- a/run_all_experiments.sh
+++ b/run_all_experiments.sh
@@ -2,6 +2,13 @@
 # Install dependencies, download datasets and run all model-dataset experiments.
 set -e
 
+# Save logs to a timestamped text file while also printing to stdout
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/run_all_experiments_$(date +'%Y%m%d_%H%M%S').txt"
+echo "Saving logs to $LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 # 1. Install Python requirements
 pip install -r requirements.txt
 


### PR DESCRIPTION
## Summary
- Save run_all_experiments.sh output to a timestamped log file via `tee`
- Document how to run the all-experiments script and where logs are stored

## Testing
- `bash -n run_all_experiments.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68983418a2b0832397c85088391a0321