### PR TITLE
fix: install PyG extensions separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ This repository contains a small collection of scripts for experimenting with va
 ## Getting Started
 1. Install dependencies:
    ```bash
-   pip install -r requirements.txt  # if provided
+   pip install -r requirements.txt
    ```
-   PyTorch and PyTorch Geometric must be installed with versions that match your system and CUDA setup.
-   For large datasets we rely on the `NeighborLoader` from PyTorch Geometric.
-   Install the optional extensions (`torch-scatter`, `torch-sparse` and `pyg_lib`)
-   so mini-batch sampling works and GPU memory usage stays low. If these packages
-   need to be compiled from source, ensure the `pybind11` headers are available
-   (e.g. `pip install pybind11`). When these extensions are missing, a slower
-   fallback called `SimpleNeighborLoader` implemented in pure Python will be used.
+   `run_all_experiments.sh` installs the PyTorch Geometric extensions
+   (`torch-scatter`, `torch-sparse`, `pyg_lib`, etc.) after ensuring they match the
+   detected PyTorch/CUDA version. If you install requirements manually you can
+   omit these optional packages or install them separately.
+   When the extensions are missing, a slower fallback loader implemented in pure
+   Python will be used.
 2. Download the datasets from the provided Google Drive folder by following [DOWNLOAD_INSTRUCTIONS.md](DOWNLOAD_INSTRUCTIONS.md).
    The archives will create a `simple_data/` directory containing `.pt` files.
 3. Run an experiment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,11 @@ torch
 torch-geometric
 ogb
 
-# Optional extensions for efficient neighbor sampling
-# Ensure the version string matches your installed PyTorch and CUDA
-torch-scatter
-torch-sparse
+# Optional extensions for efficient neighbor sampling. These are installed
+# separately in `run_all_experiments.sh` with wheels that match the detected
+# PyTorch/CUDA version. Uncomment below to install manually.
+# torch-scatter
+# torch-sparse
 
 
 # Additional utilities

--- a/run_all_experiments.sh
+++ b/run_all_experiments.sh
@@ -42,8 +42,9 @@ trap cleanup EXIT
 # 1) Install Python requirements (without PyQt5 to avoid SIP/packaging build issues)
 # -----------------------
 REQ_TMP=".tmp_requirements_no_gui.txt"
-# Remove any line that starts with "PyQt5" (case-insensitive)
-awk 'BEGIN{IGNORECASE=1} /^[[:space:]]*pyqt5(\b|[=<> ]).*/ {next} {print}' requirements.txt > "$REQ_TMP"
+# Remove GUI deps and PyG extension packages (installed later with the
+# correct wheel index) in a case-insensitive manner
+awk 'BEGIN{IGNORECASE=1} /^[[:space:]]*(pyqt5|torch-scatter|torch-sparse)(\b|[=<> ]).*/ {next} {print}' requirements.txt > "$REQ_TMP"
 
 echo "[INFO] Installing requirements without GUI deps…"
 pip install -r "$REQ_TMP"


### PR DESCRIPTION
## Summary
- skip PyG extension packages during initial dependency install so `torch-scatter` doesn't fail
- document optional installation of PyG extensions and install them separately

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689963ea3d9c8323bb4a82bb22dc6fa8