### PR TITLE
Handle missing pyg_lib wheels on ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ This repository contains a small collection of scripts for experimenting with va
    ```bash
    pip install -r requirements.txt
    ```
-   `run_all_experiments.sh` installs the PyTorch Geometric extensions
-   (`torch-scatter`, `torch-sparse`, `pyg_lib`, etc.) after ensuring they match the
-   detected PyTorch/CUDA version. If you install requirements manually you can
-   omit these optional packages or install them separately.
-   When the extensions are missing, a slower fallback loader implemented in pure
-   Python will be used.
+  `run_all_experiments.sh` installs the PyTorch Geometric extensions
+  (`torch-scatter`, `torch-sparse`, `pyg_lib`, etc.) after ensuring they match the
+  detected PyTorch/CUDA version. On ARM systems where the `pyg_lib` wheel is not
+  available, the script skips it automatically.
+  If you install requirements manually you can omit these optional packages or
+  install them separately. When the extensions are missing, a slower fallback
+  loader implemented in pure Python will be used.
 2. Download the datasets from the provided Google Drive folder by following [DOWNLOAD_INSTRUCTIONS.md](DOWNLOAD_INSTRUCTIONS.md).
    The archives will create a `simple_data/` directory containing `.pt` files.
 3. Run an experiment:

--- a/run_all_experiments.sh
+++ b/run_all_experiments.sh
@@ -72,6 +72,16 @@ else:
 
 index = f"https://data.pyg.org/whl/{tag}.html"
 pkgs = ["pyg_lib", "torch_scatter", "torch_sparse", "torch_cluster", "torch_spline_conv"]
+
+# 'pyg_lib' does not currently provide wheels for ARM architectures which
+# causes `pip install` to fail.  Skip it on those systems so the remaining
+# extensions can still be installed.
+import platform
+arch = platform.machine().lower()
+if arch in {"aarch64", "arm64"}:
+    print(f"[WARN] Skipping pyg_lib: no wheel for architecture '{arch}'", flush=True)
+    pkgs.remove("pyg_lib")
+
 cmd = [sys.executable, "-m", "pip", "install", "-U"] + pkgs + ["-f", index]
 print("[INFO] Installing PyG extensions from:", index, flush=True)
 print("[INFO] Command:", " ".join(cmd), flush=True)


### PR DESCRIPTION
## Summary
- Skip `pyg_lib` install in `run_all_experiments.sh` when running on ARM to avoid pip failures
- Document automatic skip of `pyg_lib` on ARM in README

## Testing
- `bash -n run_all_experiments.sh`


------
https://chatgpt.com/codex/tasks/task_e_68997574308c8323a4ccfd4a1ddbaf8f